### PR TITLE
Add a --history-resume option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,14 @@ starting from a certain day, and ``--history=DD-HH:MM:SS`` starts
 collecting from a given interval of time ago (the time format is as in
 Slurm).
 
+To resume from where you left off, first run with one of the history
+options.  Then, you can do ``--history-resume`` (no ``-u`` needed) and
+it will continue fetching day-by-day from the time you last fetched::
+
+  slurm2sql.py --history-days=N -u sincejuly.sqlite3 -- -a
+  slurm2sql.py --history-resume sincejuly.sqlite3 -- -a
+
+
 
 It can also be used from Python as what is essentially a glorified
 parser::

--- a/slurm2sql.py
+++ b/slurm2sql.py
@@ -54,7 +54,7 @@ def datetime_timestamp(dt):
     - Only needed because we support python 2"""
     if hasattr(dt, 'timestamp'): # python3
         return dt.timestamp()
-    return time.mktime((dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second))
+    return time.mktime(dt.timetuple())
 
 def slurmtime(x):
     """Parse slurm time of format [dd-[hh:]]mm:ss"""

--- a/slurm2sql.py
+++ b/slurm2sql.py
@@ -491,6 +491,7 @@ def main(argv=sys.argv[1:], db=None, raw_sacct=None):
 
     if args.verbose:
         logging.lastResort.setLevel(logging.DEBUG)
+    LOG.debug(args)
     if args.quiet:
         logging.lastResort.setLevel(logging.WARN)
 

--- a/slurm2sql.py
+++ b/slurm2sql.py
@@ -48,6 +48,14 @@ def unixtime(x):
     if x == 'Unknown':  return None
     return time.mktime(time.strptime(x, '%Y-%m-%dT%H:%M:%S'))
 
+def datetime_timestamp(dt):
+    """Convert a datetime object to unixtime
+
+    - Only needed because we support python 2"""
+    if hasattr(dt, 'timestamp'): # python3
+        return dt.timestamp()
+    return time.mktime((dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second))
+
 def slurmtime(x):
     """Parse slurm time of format [dd-[hh:]]mm:ss"""
     if not x: return None
@@ -68,6 +76,13 @@ def slurmtime(x):
         if len(hms) >= 2:   seconds +=        float(hms[-1])       # sec
         if len(hms) >= 1:   seconds += 60   * int(hms[-2] if len(hms)>=2 else hms[-1])  # min
     return seconds
+
+def slurm_timestamp(x):
+    """Convert a datetime to the Slurm format of timestamp
+    """
+    if not isinstance(x, datetime.datetime):
+        x = datetime.datetime.fromtimestamp(x - 5)
+    return x.strftime('%Y-%m-%dT%H:%M:%S')
 
 def str_unknown(x):
     if x == 'Unknown': return None
@@ -457,6 +472,8 @@ def main(argv=sys.argv[1:], db=None, raw_sacct=None):
                              "instead insert or update rows")
     parser.add_argument('--history',
                         help="Scrape dd-hh:mm:ss or [hh:]mm:ss from the past to now (Slurm time format)")
+    parser.add_argument('--history-resume', action='store_true',
+                        help="Day-by-day collect history, starting from last collection.")
     parser.add_argument('--history-days', type=int,
                         help="Day-by-day collect history, starting this many days ago.")
     parser.add_argument('--history-start',
@@ -480,7 +497,7 @@ def main(argv=sys.argv[1:], db=None, raw_sacct=None):
     # db is only given as an argument in tests (normally)
     if db is None:
         # Delete existing database unless --update/-u is given
-        if not args.update and os.path.exists(args.db):
+        if not (args.update or args.history_resume) and os.path.exists(args.db):
             os.unlink(args.db)
         db = sqlite3.connect(args.db)
 
@@ -488,10 +505,12 @@ def main(argv=sys.argv[1:], db=None, raw_sacct=None):
 
     # If --history-days, get just this many days history
     if (args.history is not None
+        or args.history_resume
         or args.history_days is not None
         or args.history_start is not None):
         errors = get_history(db, sacct_filter=sacct_filter,
                             history=args.history,
+                            history_resume=args.history_resume,
                             history_days=args.history_days,
                             history_start=args.history_start,
                             history_end=args.history_end,
@@ -514,7 +533,8 @@ def main(argv=sys.argv[1:], db=None, raw_sacct=None):
 
 
 def get_history(db, sacct_filter=['-a'],
-                history=None, history_days=None, history_start=None, history_end=None,
+                history=None, history_resume=None, history_days=None,
+                history_start=None, history_end=None,
                 jobs_only=False, raw_sacct=None):
     """Get history for a certain period of days.
 
@@ -526,7 +546,17 @@ def get_history(db, sacct_filter=['-a'],
     errors = 0
     now = datetime.datetime.now().replace(microsecond=0)
     today = datetime.date.today()
-    if history is not None:
+    if history_resume:
+        try:
+            start = get_last_timestamp(db)
+        except sqlite3.OperationalError:
+            import traceback
+            traceback.print_exc()
+            print()
+            print("Error fetching last start time (see above)", file=sys.stderr)
+            exit(5)
+        start = datetime.datetime.fromtimestamp(start - 5)
+    elif history is not None:
         start = now - datetime.timedelta(seconds=slurmtime(history))
     elif history_days is not None:
         start = datetime.datetime.combine(today - datetime.timedelta(days=history_days), datetime.time())
@@ -541,15 +571,17 @@ def get_history(db, sacct_filter=['-a'],
     day_interval = 1
     while start <= stop:
         end = start+datetime.timedelta(days=day_interval)
+        end = end.replace(hour=0, minute=0, second=0, microsecond=0)
         new_filter = sacct_filter + [
-            '-S', start.strftime('%Y-%m-%dT%H:%M:%S'),
-            '-E', end.strftime('%Y-%m-%dT%H:%M:%S'),
+            '-S', slurm_timestamp(start),
+            '-E', slurm_timestamp(end),
             ]
         LOG.debug(new_filter)
         LOG.info("%s %s", days_ago, start.date() if history_days is not None else start)
         errors += slurm2sql(db, sacct_filter=new_filter, update=True, jobs_only=jobs_only,
                             raw_sacct=raw_sacct)
         db.commit()
+        update_last_timestamp(db, update_time=end)
         start = end
         days_ago -= day_interval
     return errors
@@ -598,6 +630,7 @@ def slurm2sql(db, sacct_filter=['-a'], update=False, jobs_only=False,
     create_columns = ', '.join('"'+c.strip('_')+'"' for c in COLUMNS)
     create_columns = create_columns.replace('JobIDSlurm"', 'JobIDSlurm" UNIQUE')
     db.execute('CREATE TABLE IF NOT EXISTS slurm (%s)'%create_columns)
+    db.execute('CREATE TABLE IF NOT EXISTS meta_slurm_lastupdate (id INTEGER PRIMARY KEY, update_time REAL)')
     db.execute('CREATE VIEW IF NOT EXISTS allocations AS select * from slurm where JobStep is null;')
     db.execute('PRAGMA journal_mode = WAL;')
     db.commit()
@@ -666,6 +699,25 @@ def slurm2sql(db, sacct_filter=['-a'], update=False, jobs_only=False,
             db.commit()
     db.commit()
     return errors
+
+
+def update_last_timestamp(db, update_time=None):
+    """Update the last update time in the database, for resuming.
+
+    Updates the one row of the meta_slurm_lastupdate with the latest
+    unix timestamp, as passed as an argument (or now)
+    """
+    if update_time is None:
+        update_time = time.time()
+    if isinstance(update_time, datetime.datetime):
+        update_time = datetime_timestamp(update_time)
+    update_time = min(update_time, time.time())
+    db.execute("INSERT OR REPLACE INTO meta_slurm_lastupdate (id, update_time) VALUES (0, ?)", (update_time, ))
+    db.commit()
+
+def get_last_timestamp(db):
+    """Return the last update timestamp from the database"""
+    return db.execute('SELECT update_time FROM meta_slurm_lastupdate').fetchone()[0]
 
 
 if __name__ == "__main__":

--- a/test.py
+++ b/test.py
@@ -162,6 +162,10 @@ def test_slurm_time():
 
 def test_history_last_timestamp(db):
     """Test update_last_timestamp and get_last_timestamp functions"""
+    import io
+    # initialize db with null input - this just forces table creation.
+    slurm2sql.slurm2sql(db, raw_sacct=io.StringIO())
+    # Set last update and get it again immediately
     slurm2sql.update_last_timestamp(db, 13)
     assert slurm2sql.get_last_timestamp(db) == 13
 

--- a/test.py
+++ b/test.py
@@ -160,6 +160,31 @@ def test_slurm_time():
     assert slurm2sql.slurmtime('3-13:10') == 3600*24*3 + 13*3600 + 600
     assert slurm2sql.slurmtime('3-13') == 3600*24*3 + 13*3600
 
+def test_history_last_timestamp(db):
+    """Test update_last_timestamp and get_last_timestamp functions"""
+    slurm2sql.update_last_timestamp(db, 13)
+    assert slurm2sql.get_last_timestamp(db) == 13
+
+def test_history_resume_basic(db, data1):
+    """Test --history-resume"""
+    # Run it once.  Is the update_time approximately now?
+    slurm2sql.main(['dummy', '--history-days=1'], raw_sacct=data1, db=db)
+    update_time = slurm2sql.get_last_timestamp(db)
+    assert abs(update_time - time.time()) < 5
+    # Wait 1s, is update time different?
+    time.sleep(1.1)
+    slurm2sql.main(['dummy', '--history-resume'], raw_sacct=data1, db=db)
+    assert update_time != slurm2sql.get_last_timestamp(db)
+
+def test_history_resume_timestamp(db, data1, caplog):
+    """Test --history-resume's exact timestamp"""
+    # Run once to get an update_time
+    slurm2sql.main(['dummy', '--history-days=1'], raw_sacct=data1, db=db)
+    update_time = slurm2sql.get_last_timestamp(db)
+    caplog.clear()
+    # Run again and make sure that we filter based on that update_time
+    slurm2sql.main(['dummy', '--history-resume'], raw_sacct=data1, db=db)
+    assert slurm2sql.slurm_timestamp(update_time) in caplog.text
 
 #
 # Test data generation


### PR DESCRIPTION
- This remembers where the last --history-* command left off, and
  resumes data collection (in 1-day increments) from that point.