### PR TITLE
Fix data error when Timelimit set to Partition_Limit

### DIFF
--- a/slurm2sql.py
+++ b/slurm2sql.py
@@ -59,6 +59,7 @@ def datetime_timestamp(dt):
 def slurmtime(x):
     """Parse slurm time of format [dd-[hh:]]mm:ss"""
     if not x: return None
+    if x == "Partition_Limit": return None
     seconds = 0
     # The anchor is different if there is '-' or not.  With '-' it is [dd]-hh[:mm[:ss]].  Without it is mm[:ss] first, then hh:mm:ss
     if '-' in x:


### PR DESCRIPTION
The Timelimit field can be set to the string Partition_Limit
in cases where a user cancels a job.  This is the value chosen
by slurm's job_info.c when time_limit has no value.

Update the slurmtime() function to detect this value and return
None if present.  This avoids a parse error for the Timelimit
column.

Fixes issue #3