### PR TITLE
Add regex to capture slurm version

### DIFF
--- a/slurm2sql.py
+++ b/slurm2sql.py
@@ -746,8 +746,10 @@ def get_last_timestamp(db):
 
 def slurm_version(cmd=['sacct', '--version']):
     """Return the version number of Slurm, as a tuple"""
-    # example output: b'slurm 18.08.8\n'
+    # example output: b'slurm 18.08.8\n' or slurm 19.05.7-Bull.1.0
     slurm_version = subprocess.check_output(cmd).decode()
+    slurm_version = re.match(r"slurm\s[0-9]*\.[0-9]*\.[0-9]*", slurm_version)
+    slurm_version = (slurm_version.group(0))
     slurm_version = slurm_version.split()[1].split('.')  # ['18', '08', '8']
     slurm_version = tuple(int(x) for x in slurm_version)
     return slurm_version

--- a/slurm2sql.py
+++ b/slurm2sql.py
@@ -748,10 +748,9 @@ def slurm_version(cmd=['sacct', '--version']):
     """Return the version number of Slurm, as a tuple"""
     # example output: b'slurm 18.08.8\n' or slurm 19.05.7-Bull.1.0
     slurm_version = subprocess.check_output(cmd).decode()
-    slurm_version = re.match(r"slurm\s[0-9]*\.[0-9]*\.[0-9]*", slurm_version)
-    slurm_version = (slurm_version.group(0))
-    slurm_version = slurm_version.split()[1].split('.')  # ['18', '08', '8']
-    slurm_version = tuple(int(x) for x in slurm_version)
+    slurm_version = re.match(r"slurm\s([0-9]+)\.([0-9]+)\.([0-9]+)", slurm_version)
+    slurm_version = tuple(int(x) for x in slurm_version.groups())
+    print(slurm_version)
     return slurm_version
 
 

--- a/test.py
+++ b/test.py
@@ -217,10 +217,16 @@ def test_history_resume_timestamp(db, data1, caplog):
     slurm2sql.main(['dummy', '--history-resume'], raw_sacct=data1, db=db)
     assert slurm2sql.slurm_timestamp(update_time) in caplog.text
 
-def test_slurm_version():
+@pytest.mark.parametrize(
+    "string,version",
+    [("slurm 20.11.1", (20, 11, 1)),
+     ("slurm 19.5.0", (19, 5, 0)),
+     ("slurm 19.05.7-Bull.1.0", (19, 5, 7)),
+    ])
+def test_slurm_version(string, version):
     """Test slurm version detection"""
-    v = slurm2sql.slurm_version(cmd=['echo', 'slurm 20.11.1'])
-    assert v == (20, 11, 1)
+    v = slurm2sql.slurm_version(cmd=['echo', string])
+    assert v == version
 
 
 # Test slurm 20.11 version


### PR DESCRIPTION
Capture slurm version in cases where other slurm is used 

e.g. slurm 19.05.7-Bull.1.0