### PR TITLE
Fix quiet flag functionality

### DIFF
--- a/slurm2sql.py
+++ b/slurm2sql.py
@@ -532,9 +532,9 @@ def main(argv=sys.argv[1:], db=None, raw_sacct=None):
 
     if args.verbose:
         logging.lastResort.setLevel(logging.DEBUG)
-    LOG.debug(args)
     if args.quiet:
         logging.lastResort.setLevel(logging.WARN)
+    LOG.debug(args)
 
     # db is only given as an argument in tests (normally)
     if db is None:


### PR DESCRIPTION
This PR fixes the quiet flag functionality. In the current version setting `--quiet` still prints the command line arguments.

This is because the command line argument logging is done before the logging level has been set.

This PR reverses the order: the logging level is set first and arguments are logged afterwards.