### PR TITLE
Fix memeff when alloc is reported as zero

### DIFF
--- a/slurm2sql.py
+++ b/slurm2sql.py
@@ -502,7 +502,9 @@ class slurmMemEff2(linefunc):
         m_used = RE_TRES_MEM.search(row['TRESUsageInTot'])
         m_alloc = RE_TRES_MEM.search(row['AllocTRES'])
         if m_alloc and m_used:
-            return float_bytes(m_used.group(1)) / float_bytes(m_alloc.group(1))
+            alloc = float_bytes(m_alloc.group(1))
+            if alloc == 0:  return None
+            return float_bytes(m_used.group(1)) / alloc
         return None
 
 

--- a/test.py
+++ b/test.py
@@ -162,6 +162,18 @@ def test_cpueff(db):
     assert fetch(db, 1, 'TotalCPU') == 1500
     assert fetch(db, 1, 'CPUeff', table='eff') == 0.5
 
+def test_memeff(db):
+    data = """
+    JobID,AllocTRES,TRESUsageInTot
+    1,mem=1000K,mem=500K
+    2,mem=0K,mem=0K
+    """
+    slurm2sql.slurm2sql(db, [], csv_input=csvdata(data))
+    print(db.execute('select * from eff;').fetchall())
+    assert fetch(db, 1, 'Memeff', table='eff') == 0.5
+    assert fetch(db, 2, 'Memeff', table='eff') == None
+
+
 def test_gpueff(db):
     data = """
     JobID,AllocTRES,TRESUsageInTot


### PR DESCRIPTION
- Apparently sometime Slurm can report zero bytes allocated.  This doesn't make sense, but it's not slurm2sql's job to make it make sense.  This change prevents a crash and make the memeff in these cases 'null', so that an observer can inspect what's going wrong.
- Closes: #20