### PR TITLE
Fix DuckDB compatibility: Quote reserved keyword "End" in eff view

### DIFF
--- a/slurm2sql.py
+++ b/slurm2sql.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     HAS_DUCKDB = False
 
-__version__ = '0.9.9' # Bumped version for DuckDB support
+__version__ = '0.9.8' 
 
 LOG = logging.getLogger('slurm2sql')
 LOG.setLevel(logging.DEBUG)


### PR DESCRIPTION
Issue: DuckDB fails to parse the view "eff" because End is interpreted as a keyword.

Fix: Quotes around End > max("End") AS "End"

Example: 
``` 
import duckdb

con = duckdb.connect()
con.execute("ATTACH 'test.sqlite3' AS mydb (TYPE SQLITE);")

print("Table 'slurm':", con.execute('SELECT count(*) FROM mydb.slurm').fetchone())

#View access FAILS
print("View 'eff':", con.execute('SELECT count(*) FROM mydb.eff').fetchone())

print("View 'steps':", con.execute('SELECT count(*) FROM mydb.steps').fetchone())

print("View 'alloc':", con.execute('SELECT count(*)FROM mydb.allocations').fetchone()) ```

----------

>$ python3 test.py
Table 'slurm': (10247,)
Traceback (most recent call last):
  File "test.py", line 11, in <module>
  print("View 'eff':", con.execute('SELECT count(*) FROM mydb.eff').fetchone())
_duckdb.ParserException: Parser Error: syntax error at or near "End"

