### PR TITLE
A few changes wrt job steps and the efficiency table

### DIFF
--- a/slurm2sql.py
+++ b/slurm2sql.py
@@ -938,7 +938,7 @@ def slurm2sql(db, sacct_filter=['-a'], update=False, jobs_only=False,
                'JobIDnostep AS JobID, '
                'max(User) AS User, '
                'max(Partition) AS Partition, '
-               'max(JobName) AS JobName, '
+               '(SELECT s2.JobName FROM slurm AS s2 WHERE s2.JobIDnostep = slurm1.JobIDnostep AND s2.JobID = s2.JobIDnostep LIMIT 1) AS JobName,'
                'group_concat(SubmitLine, \'\n\') AS SubmitLines, '
                'Account, '
                '(SELECT State FROM allocations AS allocations2 WHERE allocations2.jobid=slurm1.JobIDnostep) AS State, '

--- a/slurm2sql.py
+++ b/slurm2sql.py
@@ -938,7 +938,7 @@ def slurm2sql(db, sacct_filter=['-a'], update=False, jobs_only=False,
                'JobIDnostep AS JobID, '
                'max(User) AS User, '
                'max(Partition) AS Partition, '
-               '(SELECT s2.JobName FROM slurm AS s2 WHERE s2.JobIDnostep = slurm1.JobIDnostep AND s2.JobID = s2.JobIDnostep LIMIT 1) AS JobName,'
+               '(SELECT s2.JobName FROM slurm AS s2 WHERE s2.JobIDnostep = slurm1.JobIDnostep AND s2.JobStep IS null LIMIT 1) AS JobName,'
                'group_concat(SubmitLine, \'\n\') AS SubmitLines, '
                'Account, '
                '(SELECT State FROM allocations AS allocations2 WHERE allocations2.jobid=slurm1.JobIDnostep) AS State, '

--- a/slurm2sql.py
+++ b/slurm2sql.py
@@ -945,7 +945,7 @@ def slurm2sql(db, sacct_filter=['-a'], update=False, jobs_only=False,
                #'State AS State, '
                'NodeList, '
                'Time, '
-               'TimeLimit, '
+               'max(TimeLimit) AS TimeLimit, '
                'min(Start) AS Start, '
                'max(End) AS End, '
                'max(NNodes) AS NNodes, '


### PR DESCRIPTION
This PR updates the JobName column such, that it sets the JobName not to the "max" of job names, which is the lexographical max, - quite inconvenient - but the name of the primary job step (which is the name given by the user).
It also sets Timelimit to the max timelimit of any job step, which is more appropriate than just any (which can be none even if one exists)